### PR TITLE
fix api change of del_timer since v6.15

### DIFF
--- a/src/bcmsdstd_linux.c
+++ b/src/bcmsdstd_linux.c
@@ -197,7 +197,11 @@ sdstd_3_osclean_tuning(sdioh_info_t *sd)
 	struct sdos_info *sdos = (struct sdos_info *)sd->sdos_info;
 	if (atomic_read(&sdos->timer_enab) == TRUE) {
 		/* disable timer if it was running */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
+		timer_delete_sync(&sdos->tuning_timer);
+#else
 		del_timer_sync(&sdos->tuning_timer);
+#endif
 		atomic_set(&sdos->timer_enab, FALSE);
 	}
 	tasklet_kill(&sdos->tuning_tasklet);
@@ -495,7 +499,11 @@ void sdstd_enable_disable_periodic_timer(sdioh_info_t *sd, uint val)
 		}
 	    if (val == SD_DHD_DISABLE_PERIODIC_TUNING) {
 			/* stop periodic timer */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
+		   timer_delete_sync(&sdos->tuning_timer);
+#else
 		   del_timer_sync(&sdos->tuning_timer);
+#endif
 		}
 }
 #endif /* debugging purpose */

--- a/src/dhd_ip.c
+++ b/src/dhd_ip.c
@@ -459,7 +459,11 @@ int dhd_tcpack_suppress_set(dhd_pub_t *dhdp, uint8 mode)
 						tcpack_info_t *tcpack_info_tbl =
 							&tcpack_sup_module->tcpack_info_tbl[i];
 #ifndef TCPACK_SUPPRESS_HOLD_HRT
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
+						timer_delete(&tcpack_info_tbl->timer);
+#else
 						del_timer(&tcpack_info_tbl->timer);
+#endif
 #else
 						hrtimer_cancel(&tcpack_info_tbl->timer.timer);
 #endif /* TCPACK_SUPPRESS_HOLD_HRT */
@@ -558,7 +562,11 @@ dhd_tcpack_info_tbl_clean(dhd_pub_t *dhdp)
 	if (dhdp->tcpack_sup_mode == TCPACK_SUP_HOLD) {
 		for (i = 0; i < TCPACK_INFO_MAXNUM; i++) {
 #ifndef TCPACK_SUPPRESS_HOLD_HRT
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
+			timer_delete_sync(&tcpack_sup_mod->tcpack_info_tbl[i].timer);
+#else
 			del_timer_sync(&tcpack_sup_mod->tcpack_info_tbl[i].timer);
+#endif
 #else
 			hrtimer_cancel(&tcpack_sup_mod->tcpack_info_tbl[i].timer.timer);
 #endif /* TCPACK_SUPPRESS_HOLD_HRT */
@@ -1343,7 +1351,11 @@ dhd_tcpack_hold(dhd_pub_t *dhdp, void *pkt, int ifidx)
 
 		if (!hold) {
 #ifndef TCPACK_SUPPRESS_HOLD_HRT
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
+			timer_delete_sync(&tcpack_info_tbl[i].timer);
+#else
 			del_timer_sync(&tcpack_info_tbl[i].timer);
+#endif
 #else
 			hrtimer_cancel(&tcpack_sup_mod->tcpack_info_tbl[i].timer.timer);
 #endif /* TCPACK_SUPPRESS_HOLD_HRT */

--- a/src/dhd_linux.c
+++ b/src/dhd_linux.c
@@ -10166,7 +10166,11 @@ dhd_bus_start(dhd_pub_t *dhdp)
 		DHD_GENERAL_LOCK(&dhd->pub, flags);
 		dhd->wd_timer_valid = FALSE;
 		DHD_GENERAL_UNLOCK(&dhd->pub, flags);
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
+		timer_delete_sync(&dhd->timer);
+#else
 		del_timer_sync(&dhd->timer);
+#endif
 
 #endif /* !BCMPCIE_OOB_HOST_WAKE */
 		DHD_STOP_RPM_TIMER(&dhd->pub);
@@ -10225,7 +10229,11 @@ dhd_bus_start(dhd_pub_t *dhdp)
 		DHD_GENERAL_LOCK(&dhd->pub, flags);
 		dhd->wd_timer_valid = FALSE;
 		DHD_GENERAL_UNLOCK(&dhd->pub, flags);
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
+		timer_delete_sync(&dhd->timer);
+#else
 		del_timer_sync(&dhd->timer);
+#endif
 		DHD_ERROR(("%s failed bus is not ready\n", __FUNCTION__));
 		DHD_STOP_RPM_TIMER(&dhd->pub);
 #ifdef BCMSDIO
@@ -10248,7 +10256,11 @@ dhd_bus_start(dhd_pub_t *dhdp)
 		DHD_GENERAL_LOCK(&dhd->pub, flags);
 		dhd->wd_timer_valid = FALSE;
 		DHD_GENERAL_UNLOCK(&dhd->pub, flags);
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
+		timer_delete_sync(&dhd->timer);
+#else
 		del_timer_sync(&dhd->timer);
+#endif
 		DHD_ERROR(("%s failed to sync with dongle\n", __FUNCTION__));
 		DHD_OS_WD_WAKE_UNLOCK(&dhd->pub);
 		return ret;
@@ -14341,7 +14353,11 @@ void dhd_detach(dhd_pub_t *dhdp)
 	dhd->wd_timer_valid = FALSE;
 	DHD_GENERAL_UNLOCK(&dhd->pub, flags);
 	if (timer_valid)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
+		timer_delete_sync(&dhd->timer);
+#else
 		del_timer_sync(&dhd->timer);
+#endif
 	DHD_STOP_RPM_TIMER(&dhd->pub);
 
 #ifdef BCMDBUS
@@ -15352,7 +15368,11 @@ dhd_os_wd_timer(void *bus, uint wdtick)
 	if (!wdtick && dhd->wd_timer_valid == TRUE) {
 		dhd->wd_timer_valid = FALSE;
 		DHD_GENERAL_UNLOCK(pub, flags);
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
+		timer_delete_sync(&dhd->timer);
+#else
 		del_timer_sync(&dhd->timer);
+#endif
 #ifdef BCMSDIO
 		DHD_OS_WD_WAKE_UNLOCK(pub);
 #endif /* BCMSDIO */

--- a/src/dhd_linux_pktdump.c
+++ b/src/dhd_linux_pktdump.c
@@ -576,7 +576,11 @@ dhd_dump_mod_pkt_timer(dhd_pub_t *dhdp, uint16 rsn)
 
 	pktcnts = (pkt_cnts_log_t *)(dhdp->pktcnts);
 	if (timer_pending(&pktcnts->pktcnt_timer)) {
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
+		timer_delete_sync(&pktcnts->pktcnt_timer);
+#else
 		del_timer_sync(&pktcnts->pktcnt_timer);
+#endif
 	}
 
 	bzero(&pktcnts->arp_cnt, sizeof(pkt_cnt_t));
@@ -623,7 +627,11 @@ dhd_dump_pkt_deinit(dhd_pub_t *dhdp)
 
 	pktcnts = (pkt_cnts_log_t *)(dhdp->pktcnts);
 	pktcnts->enabled = FALSE;
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
+	timer_delete_sync(&pktcnts->pktcnt_timer);
+#else
 	del_timer_sync(&pktcnts->pktcnt_timer);
+#endif
 	MFREE(dhdp->osh, dhdp->pktcnts, sizeof(pkt_cnts_log_t));
 	dhdp->pktcnts = NULL;
 }
@@ -640,7 +648,11 @@ dhd_dump_pkt_clear(dhd_pub_t *dhdp)
 
 	pktcnts = (pkt_cnts_log_t *)(dhdp->pktcnts);
 	pktcnts->enabled = FALSE;
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
+	timer_delete_sync(&pktcnts->pktcnt_timer);
+#else
 	del_timer_sync(&pktcnts->pktcnt_timer);
+#endif
 	pktcnts->reason = 0;
 	bzero(&pktcnts->arp_cnt, sizeof(pkt_cnt_t));
 	bzero(&pktcnts->dns_cnt, sizeof(pkt_cnt_t));

--- a/src/include/linuxver.h
+++ b/src/include/linuxver.h
@@ -407,9 +407,16 @@ extern void timer_cb_compat(struct timer_list *tl);
 #define timer_set_private(timer_compat, priv) (timer_compat)->arg = priv
 #define timer_expires(timer_compat) (timer_compat)->timer.expires
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
+#define timer_delete(t) timer_delete(&((t)->timer))
+#ifndef timer_delete_sync
+#define timer_delete_sync(t) timer_delete_sync(&((t)->timer))
+#endif
+#else
 #define del_timer(t) del_timer(&((t)->timer))
 #ifndef del_timer_sync
 #define del_timer_sync(t) del_timer_sync(&((t)->timer))
+#endif
 #endif
 #define timer_pending(t) timer_pending(&((t)->timer))
 #define add_timer(t) add_timer(&((t)->timer))
@@ -487,8 +494,13 @@ static inline void tasklet_init(struct tasklet_struct *tasklet,
 
 #define tasklet_kill(tasklet)	{ do {} while (0); }
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
+/* 6.15.x introduced timer_delete_sync() */
+#define timer_delete_sync(timer) timer_delete(timer)
+#else
 /* 2.4.x introduced del_timer_sync() */
 #define del_timer_sync(timer) del_timer(timer)
+#endif
 
 #else
 

--- a/src/include/wlioctl.h
+++ b/src/include/wlioctl.h
@@ -24856,7 +24856,11 @@ typedef struct wl_mlo_emlsr_ctrl_v1 {
 typedef struct wl_mlo_mld_ap_op {
 	uint8	op_code;		/* WL_MLO_CMD_MLD_AP_OP_ADD/DEL */
 	uint8	link_id;
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
+	uint16	timer_delete;		/* delete timer in units of TBTT */
+#else
 	uint16	del_timer;		/* delete timer in units of TBTT */
+#endif
 } wl_mlo_mld_ap_op_t;
 
 /* Current version for wlc_clm_power_limits_req_t structure and flags */

--- a/src/linux_osl.c
+++ b/src/linux_osl.c
@@ -2000,7 +2000,11 @@ osl_timer_del(osl_t *osh, osl_timer_t *t)
 	if (t->set) {
 		t->set = FALSE;
 		if (t->timer) {
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
+			timer_delete(t->timer);
+#else
 			del_timer(t->timer);
+#endif
 			MFREE(NULL, t->timer, sizeof(timer_list_compat_t));
 		}
 #ifdef BCMDBG

--- a/src/wl_cfg_btcoex.c
+++ b/src/wl_cfg_btcoex.c
@@ -338,7 +338,11 @@ static void wl_cfg80211_bt_handler(struct work_struct *work)
 
 	if (btcx_inf->timer_on) {
 		btcx_inf->timer_on = 0;
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
+		timer_delete_sync(&btcx_inf->timer);
+#else
 		del_timer_sync(&btcx_inf->timer);
+#endif
 	}
 
 	switch (btcx_inf->bt_state) {
@@ -444,7 +448,11 @@ void wl_cfg80211_btcoex_kill_handler(void)
 
 	if (btcoex_info_loc->timer_on) {
 		btcoex_info_loc->timer_on = 0;
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
+		timer_delete_sync(&btcoex_info_loc->timer);
+#else
 		del_timer_sync(&btcoex_info_loc->timer);
+#endif
 	}
 	cancel_work_sync(&btcoex_info_loc->work);
 	wl_cfg80211_btcoex_init_handler_status();
@@ -601,7 +609,11 @@ int wl_cfg80211_set_btcoex_dhcp(struct net_device *dev, dhd_pub_t *dhd, char *co
 		WL_TRACE(("disable BT DHCP Timer\n"));
 		if (btco_inf->timer_on) {
 			btco_inf->timer_on = 0;
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
+			timer_delete_sync(&btco_inf->timer);
+#else
 			del_timer_sync(&btco_inf->timer);
+#endif
 
 			if (btco_inf->bt_state != BT_DHCP_IDLE) {
 			/* ANDREY: case when framework signals DHCP end before STM timeout */

--- a/src/wl_cfgp2p.c
+++ b/src/wl_cfgp2p.c
@@ -1504,7 +1504,11 @@ wl_cfgp2p_listen_complete(struct bcm_cfg80211 *cfg, bcm_struct_cfgdev *cfgdev,
 	if (wl_get_p2p_status(cfg, LISTEN_EXPIRED) == 0) {
 		wl_set_p2p_status(cfg, LISTEN_EXPIRED);
 		if (timer_pending(&cfg->p2p->listen_timer)) {
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
+			timer_delete_sync(&cfg->p2p->listen_timer);
+#else
 			del_timer_sync(&cfg->p2p->listen_timer);
+#endif
 		}
 
 		if (cfg->afx_hdl->is_listen == TRUE &&
@@ -1615,7 +1619,11 @@ wl_cfgp2p_cancel_listen(struct bcm_cfg80211 *cfg, struct net_device *ndev,
 	 * the LISTEN state.
 	 */
 	if (timer_pending(&cfg->p2p->listen_timer)) {
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
+		timer_delete_sync(&cfg->p2p->listen_timer);
+#else
 		del_timer_sync(&cfg->p2p->listen_timer);
+#endif
 		if (notify) {
 #if defined(WL_CFG80211_P2P_DEV_IF)
 			if (bcmcfg_to_p2p_wdev(cfg))

--- a/src/wl_cfgscan.c
+++ b/src/wl_cfgscan.c
@@ -3216,7 +3216,11 @@ wl_notify_escan_complete(struct bcm_cfg80211 *cfg,
 		dev = ndev;
 	}
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
+	timer_delete_sync(&cfg->scan_timeout);
+#else
 	del_timer_sync(&cfg->scan_timeout);
+#endif
 	/* clear scan enq time on complete */
 	CLR_TS(cfg, scan_enq);
 	CLR_TS(cfg, scan_start);
@@ -3349,7 +3353,11 @@ int wl_cfg80211_scan_suppress(struct net_device *dev, int suppress)
 		return 0;
 	}
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
+	timer_delete_sync(&cfg->scan_supp_timer);
+#else
 	del_timer_sync(&cfg->scan_supp_timer);
+#endif
 
 	if ((ret = wldev_ioctl_set(dev, WLC_SET_SCANSUPPRESS,
 		&suppress, sizeof(int))) < 0) {
@@ -3648,7 +3656,11 @@ wl_notify_scan_status(struct bcm_cfg80211 *cfg, bcm_struct_cfgdev *cfgdev,
 	err = wl_inform_bss(cfg);
 
 scan_done_out:
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
+	timer_delete_sync(&cfg->scan_timeout);
+#else
 	del_timer_sync(&cfg->scan_timeout);
+#endif
 	WL_CFG_DRV_LOCK(&cfg->cfgdrv_lock, flags);
 	if (cfg->scan_request) {
 		_wl_notify_scan_done(cfg, false);
@@ -5623,7 +5635,11 @@ wl_priortize_scan_over_listen(struct bcm_cfg80211 *cfg,
 	wl_set_drv_status(cfg, FAKE_REMAINING_ON_CHANNEL, ndev);
 
 	WL_DBG(("cancel current listen timer \n"));
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
+	timer_delete_sync(&cfg->p2p->listen_timer);
+#else
 	del_timer_sync(&cfg->p2p->listen_timer);
+#endif
 
 	wl_clr_p2p_status(cfg, LISTEN_EXPIRED);
 

--- a/src/wl_escan.c
+++ b/src/wl_escan.c
@@ -393,7 +393,11 @@ wl_escan_notify_complete(struct net_device *dev,
 		wl_escan_abort(dev, escan);
 
 	if (timer_pending(&escan->scan_timeout))
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
+		timer_delete_sync(&escan->scan_timeout);
+#else
 		del_timer_sync(&escan->scan_timeout);
+#endif
 
 #if defined(ESCAN_RESULT_PATCH)
 	escan->bss_list = wl_escan_get_buf(escan);
@@ -837,7 +841,11 @@ static int
 wl_escan_reset(struct wl_escan_info *escan)
 {
 	if (timer_pending(&escan->scan_timeout))
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
+		timer_delete_sync(&escan->scan_timeout);
+#else
 		del_timer_sync(&escan->scan_timeout);
+#endif
 	escan->escan_state = ESCAN_STATE_IDLE;
 
 	return 0;
@@ -1712,7 +1720,11 @@ wl_escan_deinit(struct net_device *dev, struct wl_escan_info *escan)
 {
 	ESCAN_TRACE(dev->name, "Enter\n");
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
+	timer_delete_sync(&escan->scan_timeout);
+#else
 	del_timer_sync(&escan->scan_timeout);
+#endif
 	escan->escan_state = ESCAN_STATE_DOWN;
 
 #if defined(RSSIAVG)

--- a/src/wl_iw.c
+++ b/src/wl_iw.c
@@ -4180,7 +4180,11 @@ _iscan_sysioc_thread(void *data)
 	status = WL_SCAN_RESULTS_PARTIAL;
 	while (down_interruptible(&iscan->sysioc_sem) == 0) {
 		if (iscan->timer_on) {
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
+			timer_delete(&iscan->timer);
+#else
 			del_timer(&iscan->timer);
+#endif
 			iscan->timer_on = 0;
 		}
 

--- a/src/wl_timer.c
+++ b/src/wl_timer.c
@@ -550,7 +550,11 @@ wl_timer_dettach(dhd_pub_t *dhdp)
 
 	if (timer_params) {
 		if (timer_pending(&timer_params->timer))
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
+			timer_delete_sync(&timer_params->timer);
+#else
 			del_timer_sync(&timer_params->timer);
+#endif
 		wl_timer_deinit_priv(timer_params);
 		kfree(timer_params);
 		dhdp->timer_params = NULL;
@@ -591,7 +595,11 @@ void
 wl_timer_mod(dhd_pub_t *dhd, timer_list_compat_t *timer, uint32 tmo_ms)
 {
 	if (timer_pending(timer))
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
+		timer_delete_sync(timer);
+#else
 		del_timer_sync(timer);
+#endif
 	if (tmo_ms)
 		mod_timer(timer, jiffies + msecs_to_jiffies(tmo_ms));
 }
@@ -606,6 +614,10 @@ void
 wl_timer_deregister(struct net_device *net, timer_list_compat_t *timer)
 {
 	if (timer_pending(timer))
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
+		timer_delete_sync(timer);
+#else
 		del_timer_sync(timer);
+#endif
 }
 #endif


### PR DESCRIPTION
See: https://github.com/torvalds/linux/commit/8fa7292fee5c5240402371ea89ab285ec856c916

Build tested successful on `edge` branch with `enable_extension "bcmdhd"`, build command:
`./compile.sh build BOARD=orangepi5-ultra BRANCH=edge BUILD_DESKTOP=no BUILD_MINIMAL=no KERNEL_CONFIGURE=no RELEASE=noble ENABLE_EXTENSIONS=preset-firstrun CONSOLE_AUTOLOGIN=yes`

cc @amazingfate 