### PR TITLE
Fix build on Linux 7.2 (strncpy removal + remain_on_channel rx_addr)

### DIFF
--- a/src/include/linuxver.h
+++ b/src/include/linuxver.h
@@ -43,6 +43,43 @@
 #include <typedefs.h>
 #include <linux/version.h>
 
+/*
+ * Linux 7.2 removed strncpy(): both the declaration in <linux/string.h> and the
+ * implementation in lib/string.c are gone, the API having been deprecated in
+ * favour of strscpy(). This driver calls strncpy() in 42 places, plus wherever
+ * bcm_strncpy_s() from bcmutils.h is used, so without it the build fails with
+ * "implicit declaration of function 'strncpy'" and then would not link.
+ *
+ * Provide what the kernel used to, byte for byte the pre-removal lib/string.c
+ * implementation. Converting the call sites to strscpy() instead is not
+ * equivalent: strscpy() always NUL-terminates and never pads, whereas strncpy()
+ * pads the remainder of the destination with NULs and may leave it
+ * unterminated. Several call sites here copy into fixed-size fields that are
+ * later handled as padded buffers, so switching would be a silent behaviour
+ * change in vendor code we cannot properly test.
+ *
+ * linuxver.h is reachable from every file in the driver that calls strncpy(),
+ * so this single definition covers all of them. Define BCMDHD_HAVE_STRNCPY to
+ * suppress it on a kernel that still provides its own.
+ */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 2, 0) && !defined(BCMDHD_HAVE_STRNCPY)
+#include <linux/string.h>
+#undef strncpy
+static inline char *strncpy(char *dest, const char *src, size_t count)
+{
+	char *tmp = dest;
+
+	while (count) {
+		if ((*tmp = *src) != '\0')
+			src++;
+		tmp++;
+		count--;
+	}
+
+	return dest;
+}
+#endif /* LINUX_VERSION_CODE >= KERNEL_VERSION(7, 2, 0) */
+
 #ifndef RHEL_RELEASE_CODE
 #define RHEL_RELEASE_CODE	(0)
 #endif

--- a/src/wl_cfgscan.c
+++ b/src/wl_cfgscan.c
@@ -5653,8 +5653,15 @@ wl_priortize_scan_over_listen(struct bcm_cfg80211 *cfg,
 
 s32
 #if defined(WL_CFG80211_P2P_DEV_IF)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 2, 0)
+/* 7.2 added rx_addr to the remain_on_channel op; unused here (no MLO support) */
+wl_cfgscan_remain_on_channel(struct wiphy *wiphy, bcm_struct_cfgdev *cfgdev,
+	struct ieee80211_channel *channel, unsigned int duration, u64 *cookie,
+	const u8 *rx_addr)
+#else
 wl_cfgscan_remain_on_channel(struct wiphy *wiphy, bcm_struct_cfgdev *cfgdev,
 	struct ieee80211_channel *channel, unsigned int duration, u64 *cookie)
+#endif /* LINUX_VERSION_CODE >= KERNEL_VERSION(7, 2, 0) */
 #else
 wl_cfgscan_remain_on_channel(struct wiphy *wiphy, bcm_struct_cfgdev *cfgdev,
 	struct ieee80211_channel *channel,
@@ -5669,6 +5676,9 @@ wl_cfgscan_remain_on_channel(struct wiphy *wiphy, bcm_struct_cfgdev *cfgdev,
 	struct bcm_cfg80211 *cfg = wiphy_priv(wiphy);
 	struct wireless_dev *wdev;
 
+#if defined(WL_CFG80211_P2P_DEV_IF) && LINUX_VERSION_CODE >= KERNEL_VERSION(7, 2, 0)
+	BCM_REFERENCE(rx_addr);
+#endif
 	RETURN_EIO_IF_NOT_UP(cfg);
 
 	ndev = cfgdev_to_wlc_ndev(cfgdev, cfg);

--- a/src/wl_cfgscan.h
+++ b/src/wl_cfgscan.h
@@ -148,8 +148,14 @@ extern void wl_cfgscan_listen_complete_work(struct work_struct *work);
 extern s32 wl_cfgscan_notify_listen_complete(struct bcm_cfg80211 *cfg);
 extern s32 wl_cfgscan_cancel_listen_on_channel(struct bcm_cfg80211 *cfg, bool notify_user);
 #if defined(WL_CFG80211_P2P_DEV_IF)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 2, 0)
+extern s32 wl_cfgscan_remain_on_channel(struct wiphy *wiphy, bcm_struct_cfgdev *cfgdev,
+	struct ieee80211_channel *channel, unsigned int duration, u64 *cookie,
+	const u8 *rx_addr);
+#else
 extern s32 wl_cfgscan_remain_on_channel(struct wiphy *wiphy, bcm_struct_cfgdev *cfgdev,
 	struct ieee80211_channel *channel, unsigned int duration, u64 *cookie);
+#endif /* LINUX_VERSION_CODE >= KERNEL_VERSION(7, 2, 0) */
 #else
 extern s32 wl_cfgscan_remain_on_channel(struct wiphy *wiphy, bcm_struct_cfgdev *cfgdev,
 	struct ieee80211_channel *channel, enum nl80211_channel_type channel_type,


### PR DESCRIPTION
> **TL;DR** — Two independent Linux 7.2 API breaks stop this driver building. Both fixed, and the result is **build-tested on a real 7.2.2 arm64 tree**: unfixed fails at 39 objects, fixed produces both `.ko`s.

## The failures

Armbian CI, building `bcmdhd-sdio 101.10.591.52.27-6` against `7.2.2-edge-rockchip64` ([run 33354576463](https://github.com/armbian/ci/actions/runs/33354576463), Orange Pi 5 Max images).

### 1. `strncpy()` was removed from the kernel

```
dhd_linux.c:9925:17: error: implicit declaration of function 'strncpy'
./include/bcmutils.h:34:57: error: implicit declaration of function 'strncpy'
   34 | #define bcm_strncpy_s(dst, noOfElements, src, count)  strncpy((dst), (src), (count))
```

Not merely a missing prototype. In 7.2 the name survives in `<linux/string.h>` **only inside comments** naming its replacements, and the implementation is gone from `lib/string.c` too — so the module would not link either.

Restored as a version-gated `static inline` in `linuxver.h`, byte for byte the kernel's own pre-removal implementation. That header is reachable from **all 16** files that call `strncpy()` — directly from `dhd_linux.c`, via `dhd_pktlog.h → dhd.h → bcmutils.h → hnd_pktpool.h → osl.h → linux_pkt.h` from `dhd_common.c` — so one definition covers all 42 call sites plus every `bcm_strncpy_s()` use, with no vendor source touched. `BCMDHD_HAVE_STRNCPY` suppresses it on a kernel that still has its own.

**Why not `strscpy()`:** not equivalent. `strscpy()` always NUL-terminates and never pads; `strncpy()` pads with NULs and may leave the destination unterminated. Several call sites copy into fixed-size fields later handled as padded buffers, so the swap would be a silent behaviour change in vendor code none of us can test on hardware.

### 2. `remain_on_channel()` gained an `rx_addr` argument

Only visible once the first fix lets the build get that far:

```
wl_cfg80211.c:12225:30: error: initialization of
  'int (*)(..., u64 *, const u8 *)' from incompatible pointer type
  's32 (*)(..., u64 *)'
```

7.2 added a trailing `const u8 *rx_addr` to `remain_on_channel` in `struct cfg80211_ops`; `cancel_remain_on_channel` is unchanged. Added to `wl_cfgscan_remain_on_channel()`, definition and prototype, behind a `LINUX_VERSION_CODE` gate nested in the existing `WL_CFG80211_P2P_DEV_IF` branch — the idiom the rest of the file already uses. The argument identifies the address to receive frames on for MLO, which this driver doesn't support, so it is `BCM_REFERENCE()`d and ignored, preserving pre-7.2 behaviour.

## Build test

Cross-compiled on kernel **v7.2.2**, arm64, `aarch64-linux-gnu-gcc 15.2.0`, driving the kernel Makefile with `M=` exactly as the DKMS rules do:

| | result | objects | modules |
|---|---|---|---|
| `main` | **fails** | 39 | 0 |
| this branch | **exit 0** | 65 | 2 |

Same fully-built kernel tree in both runs, so modpost resolves against a real `Module.symvers` (21,437 symbols) rather than an empty one. Output is a genuine aarch64 module, `vermagic=7.2.2 SMP preempt mod_unload aarch64`.

187 warnings remain, all pre-existing vendor noise — 181 `-Wmissing-prototypes`, 4 `-Wempty-body`, 1 `-Wunused-variable`. This branch adds no new warning classes.

The `strncpy` shim was additionally differential-tested against libc `strncpy` over 105 source/count combinations into poisoned buffers, comparing the full destination and return value: byte-identical every time, padding and non-termination included.

**Not runtime-tested** — no Broadcom SDIO hardware here. This is a build fix.

## Please also cut a release

Armbian's `extensions/bcmdhd.sh` downloads `releases/latest` at image-build time. The newest release is `101.10.591.52.27-6` from **2026-01-23**, predating the 7.1 compatibility fixes already merged here in June. Without a new release neither those nor this reach an image.
